### PR TITLE
Update deprecated image URLs for hyperocean & hyper-pokemon themes

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -407,7 +407,7 @@
     "name": "hyper-pokemon",
     "description": "Tailor-made Pokémon themes for your Hyper terminal",
     "type": "theme",
-    "preview": "https://raw.githubusercontent.com/klauscfhq/hyper-pokemon/356542cd/media/screen%402x.png",
+    "preview": "https://raw.githubusercontent.com/klaussinani/hyper-pokemon/master/media/screen%402x.png",
     "colors": [
       "#F7DE82",
       "#E28638",
@@ -445,7 +445,7 @@
     "name": "hyperocean",
     "description": "Deep oceanic blue Hyper theme",
     "type": "theme",
-    "preview": "https://raw.githubusercontent.com/klauscfhq/hyperocean/master/media/screen.png",
+    "preview": "https://raw.githubusercontent.com/klaussinani/hyperocean/master/media/screen.png",
     "colors": [
       "#0F111A",
       "#3A75C4",


### PR DESCRIPTION
## Description

The PR introduces a couple of minor updates to the `hyperocean` & `hyper-pokemon` image URLs. The URLs used up to now are deprecated, even though fully functional, and both redirect/point to the following new ones:

- <https://raw.githubusercontent.com/klaussinani/hyper-pokemon/master/media/screen%402x.png>
- <https://raw.githubusercontent.com/klaussinani/hyperocean/master/media/screen.png>

Feel free to suggest any additional changes : )