### PR TITLE
Disable SSG with env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# If set to a truthy value will disable SSG on /store pages
+# SKIP_STORE_SSG=1

--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# If set to a truthy value will disable SSG on /store pages
-# SKIP_STORE_SSG=1

--- a/pages/store/[name]/source.js
+++ b/pages/store/[name]/source.js
@@ -16,12 +16,14 @@ export default ({ plugin, npmData, pluginMeta, cache }) => {
   // figuring out the initial activeFile from the url
   // or falling back to the first file of the plugin
   useEffect(() => {
-    const filenameInQuery = router.asPath.split('?')[1]
-    setActiveFile(
-      filenameInQuery
-        ? `/${filenameInQuery}`
-        : pluginMeta.files.find((file) => file.type === 'file').path ?? null
-    )
+    if (!router.isFallback) {
+      const filenameInQuery = router.asPath.split('?')[1]
+      setActiveFile(
+        filenameInQuery
+          ? `/${filenameInQuery}`
+          : pluginMeta.files.find((file) => file.type === 'file').path ?? null
+      )
+    }
   }, [router])
 
   const handleClickOnFile = (path) =>
@@ -76,6 +78,14 @@ export default ({ plugin, npmData, pluginMeta, cache }) => {
       ))}
     </div>
   )
+
+  if (router.isFallback) {
+    return (
+      <Page>
+        <h1 className={styles.name}>Loading...</h1>
+      </Page>
+    )
+  }
 
   return (
     <Page
@@ -146,7 +156,10 @@ export const getStaticProps = async ({ params }) => {
   }
 }
 
-export const getStaticPaths = () => ({
-  paths: plugins.map(({ name }) => ({ params: { name } })),
-  fallback: false,
-})
+export const getStaticPaths = () =>
+  process.env.SKIP_STORE_SSG
+    ? { paths: [], fallback: true }
+    : {
+        paths: plugins.map(({ name }) => ({ params: { name } })),
+        fallback: false,
+      }


### PR DESCRIPTION
We have a problematic SSG fetch on /store/[name]/source due to unpkgs rate limit. With `fallback: true` we can still verify/look at the pages if needed on preview deployments but we definitely don't need a full build with the ~500 unpkg fetches every time.

If the `SKIP_STORE_SSG` environment variables is set to a truthy value, e.g. `1` the mentioned pages won't be pre rendered.