### PR TITLE
Optimize images

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,2 +1,2 @@
 export const CLOUDINARY_PREFIX =
-  'https://res.cloudinary.com/zeit-inc/image/fetch/https://hyper.is/store/'
+  'https://res.cloudinary.com/zeit-inc/image/fetch/h_800,q_auto/https://hyper.is/store/'


### PR DESCRIPTION
We should not fetch images at the original quality.

Instead, this adds cloudinary transformation that fetches the images at automatic quality and 800 px height.