### PR TITLE
Add hyper-breeze-theme

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -635,5 +635,17 @@
       "#9272dc"
     ],
     "dateAdded": "1597807892019"
+  },
+  {
+    "name": "hyper-breeze-theme",
+    "type": "theme",
+    "description": "KDE Breeze-like theme for Hyper.",
+    "preview": "https://raw.githubusercontent.com/codipodi/hyper-breeze-theme/master/.github/screenshot.png",
+    "colors": [
+      "#31363b",
+      "#eff0f1",
+      "#1abc9c"
+    ],
+    "dateAdded": "1615929593544"
   }
 ]


### PR DESCRIPTION
I created a plugin named `hyper-breeze-theme` based on KDE Breeze. I want to register my plugin to Hyper Store.

Thank you!