### PR TITLE
Enable turborepo in single-package mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .next
 node_modules
 .vercel
+.turbo

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
       },
       "devDependencies": {
         "prettier": "^2.0.5",
-        "shell-quote": "^1.7.2"
+        "shell-quote": "^1.7.2",
+        "turbo": "^1.6.0-canary.4"
       }
     },
     "node_modules/@ampproject/toolbox-core": {
@@ -8117,6 +8118,102 @@
         "node": "*"
       }
     },
+    "node_modules/turbo": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
+      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "1.6.0-canary.4",
+        "turbo-darwin-arm64": "1.6.0-canary.4",
+        "turbo-linux-64": "1.6.0-canary.4",
+        "turbo-linux-arm64": "1.6.0-canary.4",
+        "turbo-windows-64": "1.6.0-canary.4",
+        "turbo-windows-arm64": "1.6.0-canary.4"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -15595,6 +15692,62 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "turbo": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
+      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
+      "dev": true,
+      "requires": {
+        "turbo-darwin-64": "1.6.0-canary.4",
+        "turbo-darwin-arm64": "1.6.0-canary.4",
+        "turbo-linux-64": "1.6.0-canary.4",
+        "turbo-linux-arm64": "1.6.0-canary.4",
+        "turbo-windows-64": "1.6.0-canary.4",
+        "turbo-windows-arm64": "1.6.0-canary.4"
+      }
+    },
+    "turbo-darwin-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-darwin-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-arm64": {
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
+      "dev": true,
+      "optional": true
     },
     "type": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
       },
       "devDependencies": {
         "prettier": "^2.0.5",
-        "shell-quote": "^1.7.2",
-        "turbo": "^1.6.0-canary.4"
+        "shell-quote": "^1.7.2"
       }
     },
     "node_modules/@ampproject/toolbox-core": {
@@ -8118,102 +8117,6 @@
         "node": "*"
       }
     },
-    "node_modules/turbo": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
-      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "turbo": "bin/turbo"
-      },
-      "optionalDependencies": {
-        "turbo-darwin-64": "1.6.0-canary.4",
-        "turbo-darwin-arm64": "1.6.0-canary.4",
-        "turbo-linux-64": "1.6.0-canary.4",
-        "turbo-linux-arm64": "1.6.0-canary.4",
-        "turbo-windows-64": "1.6.0-canary.4",
-        "turbo-windows-arm64": "1.6.0-canary.4"
-      }
-    },
-    "node_modules/turbo-darwin-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-darwin-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/turbo-linux-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-linux-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/turbo-windows-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/turbo-windows-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -15692,62 +15595,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "turbo": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
-      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
-      "dev": true,
-      "requires": {
-        "turbo-darwin-64": "1.6.0-canary.4",
-        "turbo-darwin-arm64": "1.6.0-canary.4",
-        "turbo-linux-64": "1.6.0-canary.4",
-        "turbo-linux-arm64": "1.6.0-canary.4",
-        "turbo-windows-64": "1.6.0-canary.4",
-        "turbo-windows-arm64": "1.6.0-canary.4"
-      }
-    },
-    "turbo-darwin-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
-      "dev": true,
-      "optional": true
-    },
-    "turbo-darwin-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
-      "dev": true,
-      "optional": true
-    },
-    "turbo-linux-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
-      "dev": true,
-      "optional": true
-    },
-    "turbo-linux-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
-      "dev": true,
-      "optional": true
-    },
-    "turbo-windows-64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
-      "dev": true,
-      "optional": true
-    },
-    "turbo-windows-arm64": {
-      "version": "1.6.0-canary.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
-      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
-      "dev": true,
-      "optional": true
     },
     "type": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
       },
       "devDependencies": {
         "prettier": "^2.0.5",
-        "shell-quote": "^1.7.2"
+        "shell-quote": "^1.7.2",
+        "turbo": "^1.5.6"
       }
     },
     "node_modules/@ampproject/toolbox-core": {
@@ -8117,6 +8118,102 @@
         "node": "*"
       }
     },
+    "node_modules/turbo": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
+      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "1.5.6",
+        "turbo-darwin-arm64": "1.5.6",
+        "turbo-linux-64": "1.5.6",
+        "turbo-linux-arm64": "1.5.6",
+        "turbo-windows-64": "1.5.6",
+        "turbo-windows-arm64": "1.5.6"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
+      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
+      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
+      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
+      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
+      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
+      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -15595,6 +15692,62 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "turbo": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
+      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
+      "dev": true,
+      "requires": {
+        "turbo-darwin-64": "1.5.6",
+        "turbo-darwin-arm64": "1.5.6",
+        "turbo-linux-64": "1.5.6",
+        "turbo-linux-arm64": "1.5.6",
+        "turbo-windows-64": "1.5.6",
+        "turbo-windows-arm64": "1.5.6"
+      }
+    },
+    "turbo-darwin-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
+      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-darwin-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
+      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
+      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
+      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
+      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
+      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
+      "dev": true,
+      "optional": true
     },
     "type": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "devDependencies": {
         "prettier": "^2.0.5",
         "shell-quote": "^1.7.2",
-        "turbo": "^1.5.6"
+        "turbo": "^1.6.0-canary.4"
       }
     },
     "node_modules/@ampproject/toolbox-core": {
@@ -8119,27 +8119,27 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
-      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
+      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.5.6",
-        "turbo-darwin-arm64": "1.5.6",
-        "turbo-linux-64": "1.5.6",
-        "turbo-linux-arm64": "1.5.6",
-        "turbo-windows-64": "1.5.6",
-        "turbo-windows-arm64": "1.5.6"
+        "turbo-darwin-64": "1.6.0-canary.4",
+        "turbo-darwin-arm64": "1.6.0-canary.4",
+        "turbo-linux-64": "1.6.0-canary.4",
+        "turbo-linux-arm64": "1.6.0-canary.4",
+        "turbo-windows-64": "1.6.0-canary.4",
+        "turbo-windows-arm64": "1.6.0-canary.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
-      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
       "cpu": [
         "x64"
       ],
@@ -8150,9 +8150,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
-      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
       "cpu": [
         "arm64"
       ],
@@ -8163,9 +8163,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
-      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
       "cpu": [
         "x64"
       ],
@@ -8176,9 +8176,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
-      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
       "cpu": [
         "arm64"
       ],
@@ -8189,9 +8189,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
-      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
       "cpu": [
         "x64"
       ],
@@ -8202,9 +8202,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
-      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
       "cpu": [
         "arm64"
       ],
@@ -15694,58 +15694,58 @@
       }
     },
     "turbo": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
-      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.6.0-canary.4.tgz",
+      "integrity": "sha512-iRh1qsrwnzXKx02qvhViMOeUAdwl2pBsrh4iuxOA3LNINnq/5g5yRiSc0dODk0Z/rWUzWv5jXQC+Kg6d1P+ZEA==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "1.5.6",
-        "turbo-darwin-arm64": "1.5.6",
-        "turbo-linux-64": "1.5.6",
-        "turbo-linux-arm64": "1.5.6",
-        "turbo-windows-64": "1.5.6",
-        "turbo-windows-arm64": "1.5.6"
+        "turbo-darwin-64": "1.6.0-canary.4",
+        "turbo-darwin-arm64": "1.6.0-canary.4",
+        "turbo-linux-64": "1.6.0-canary.4",
+        "turbo-linux-arm64": "1.6.0-canary.4",
+        "turbo-windows-64": "1.6.0-canary.4",
+        "turbo-windows-arm64": "1.6.0-canary.4"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
-      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-MX1M5NXYbQSlF9vnR8Q4Ztlm1vunk3HcvP1/STccW5rpCk/6MIqz8ZYdDK/oSE1btSfiGze0AKhtZuCBFQVsNA==",
       "dev": true,
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
-      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-2RbEtZzi+G1CejfYWecTOxKi+DkwHqIkNjOb076yaLwBAEc19U33E7MJRWLJgoP8V38zSRGzySlrKcpXoTvgog==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
-      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-WqflsR/yy206KDImjS/ARayovC9vJfjbUtKLJ3YqDpYVc/cPiC06BgsBwXBJWJysAd6r0159sYmc9+fsWstz6w==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
-      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-QOUg7w34GCyZMLCH6yGB/9P2d+Ok2YGi+CdsguzndHbscUzP8MxrGx1SOVMJHlyZcpiSJAR2Ii6orx5/0kAnBw==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
-      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-IbpsrSjZrK6Wcwcq0iUbuLCEQc9LeqD8opetCPirA6qn7diGLLjfpTSY8zCXITLJfVb34JfmqAWXllfRFtpGww==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
-      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
+      "version": "1.6.0-canary.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.0-canary.4.tgz",
+      "integrity": "sha512-eMTTIIXs6DJomgBzYhLF3hStklLxSPOKp7TTYPkBqTsOywkTjmE9W1ZWyxyx5pAWnkyx+wEbaybWsYFSdZYfBQ==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "prettier": "^2.0.5",
     "shell-quote": "^1.7.2",
-    "turbo": "^1.5.6"
+    "turbo": "^1.6.0-canary.4"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "turbo run turbobuild --single-package",
+    "turbobuild": "next build",
     "start": "next start"
   },
   "dependencies": {
@@ -27,7 +28,8 @@
   },
   "devDependencies": {
     "prettier": "^2.0.5",
-    "shell-quote": "^1.7.2"
+    "shell-quote": "^1.7.2",
+    "turbo": "^1.5.6"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "prettier": "^2.0.5",
-    "shell-quote": "^1.7.2"
+    "shell-quote": "^1.7.2",
+    "turbo": "^1.6.0-canary.4"
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "turbo run turbobuild --single-package",
+    "prebuild": "turbo --version && which turbo",
+    "build": "turbo run turbobuild",
     "turbobuild": "next build",
     "start": "next start"
   },
@@ -28,8 +29,7 @@
   },
   "devDependencies": {
     "prettier": "^2.0.5",
-    "shell-quote": "^1.7.2",
-    "turbo": "^1.6.0-canary.4"
+    "shell-quote": "^1.7.2"
   },
   "prettier": {
     "singleQuote": true,

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,8 @@
+{
+  "pipeline": {
+    "turbobuild": {
+      "inputs": ["lib/**", "components/**", "pages/**", "styles/**"],
+      "outputs": [".next/**"]
+    }
+  }
+}


### PR DESCRIPTION
I spent some time testing this site with `turbo@1.6-canary` builds with the new `--single-package` mode we're releasing (https://github.com/vercel/turborepo/pull/2157). The build command works decently well, so I figured I'd submit it to the real project as well. Looks like the website isn't updated very often, but just in case!