### PR TITLE
Fix: fixed the windows path for the config and plugin files.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -15,11 +15,11 @@ function Path({ os, path }) {
         os === 'mac'
           ? '~/Library/Application Support/Hyper/'
           : os === 'windows'
-          ? '$Env:AppData/Hyper/'
+          ? '%AppData%/Hyper/'
           : os === 'linux'
           ? '~/.config/Hyper/'
           : ''
-      }${path}`}
+      }${path}`}  
     </code>
   )
 }


### PR DESCRIPTION
Solves the https://github.com/vercel/hyper/issues/7070.
Changed the path from `$Env:AppData/Hyper` to `%AppData%/Hyper`