### PR TITLE
Add hyper-new-tab plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -508,7 +508,7 @@
     "type": "plugin",
     "preview": "https://raw.githubusercontent.com/daltonmenezes/hyper-init/master/img/hyper-init.gif",
     "dateAdded": "1541659140469"
-  },  
+  },
   {
     "name": "hyper-launch-menu",
     "description": "Launch more than one kind of shell from the menu",
@@ -635,5 +635,12 @@
       "#9272dc"
     ],
     "dateAdded": "1597807892019"
+  },
+  {
+    "name": "hyper-new-tab",
+    "description": "Add a button + to easily open a new tab in your Hyper terminal.",
+    "type": "plugin",
+    "preview": "https://raw.githubusercontent.com/gentslava/hyper-new-tab/main/demo/default.png",
+    "dateAdded": "1695024281571"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -640,7 +640,7 @@
     "name": "hyper-new-tab",
     "description": "Add a button + to easily open a new tab in your Hyper terminal.",
     "type": "plugin",
-    "preview": "https://raw.githubusercontent.com/gentslava/hyper-new-tab/main/demo/default.png",
+    "preview": "https://raw.githubusercontent.com/gentslava/hyper-new-tab/main/demo/no_theme.png",
     "dateAdded": "1695024281571"
   }
 ]


### PR DESCRIPTION
Add a button `+` to easily open a new tab in your Hyper terminal.

[Link to the repo.](https://github.com/gentslava/hyper-new-tab)

![image](https://github.com/vercel/hyper-site/assets/14369958/2494c311-0185-4615-a28d-bd0b54208339)
