### PR TITLE
chore: correct path for macOs home

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -13,7 +13,7 @@ function Path({ os, path }) {
     <code>
       {`${
         os === 'mac'
-          ? '~/Library/Application Support/Hyper/'
+          ? '~/Library/Application\ Support/Hyper/'
           : os === 'windows'
           ? '$Env:AppData/Hyper/'
           : os === 'linux'


### PR DESCRIPTION
On macOS, we need to escape whitespaces. If you copy the location from the homepage directly, you need to do this manually in shell.

Resolves #158
