### PR TITLE
Start app router migration

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,25 @@
+import '../styles/global.css'
+import Providers from './providers'
+import Script from 'next/script'
+import { GA_TRACKING_ID } from '../lib/gtag'
+
+export const metadata = {
+  title: 'Hyper',
+  description: 'The official website for the Hyper terminal',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <head>
+        <Script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
+        <Script id="gtag-init" dangerouslySetInnerHTML={{
+          __html: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${GA_TRACKING_ID}');`,
+        }} />
+      </head>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  )
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,8 @@
+import HomePage, { getStaticProps } from '../pages/index'
+
+export const revalidate = 60 * 60 * 24
+
+export default async function Page() {
+  const { props } = await getStaticProps()
+  return <HomePage {...props} />
+}

--- a/app/providers.jsx
+++ b/app/providers.jsx
@@ -1,0 +1,27 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import NProgress from 'nprogress'
+import { pageView as gTagPageView } from '../lib/gtag'
+import { SearchContext } from '../lib/search-context'
+
+export default function Providers({ children }) {
+  const [search, setSearch] = useState('')
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const timeout = setTimeout(NProgress.start, 500)
+    gTagPageView(window.location.href)
+    return () => {
+      clearTimeout(timeout)
+      setSearch('')
+      NProgress.done()
+    }
+  }, [pathname])
+
+  return (
+    <SearchContext.Provider value={{ search, setSearch }}>
+      {children}
+    </SearchContext.Provider>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,10 @@ const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
 })
 
-module.exports = withMDX({
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   pageExtensions: ['js', 'mdx'],
-})
+  experimental: { appDir: true },
+}
+
+module.exports = withMDX(nextConfig)

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mdx-js/loader": "^1.6.4",
-    "@mdx-js/react": "^1.6.4",
-    "@next/mdx": "^9.4.2",
+    "@mdx-js/loader": "^2.4.1",
+    "@mdx-js/react": "^2.4.1",
+    "@next/mdx": "^14.1.0",
     "copee": "^1.0.6",
-    "husky": "^4.2.5",
-    "image-size": "^0.9.3",
-    "lint-staged": "^10.2.3",
-    "next": "^13.0.5",
+    "husky": "^8.0.0",
+    "image-size": "^1.0.0",
+    "lint-staged": "^15.0.0",
+    "next": "^14.1.0",
     "nprogress": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -26,8 +26,8 @@
     "react-highlighter": "^0.4.3"
   },
   "devDependencies": {
-    "prettier": "^2.0.5",
-    "shell-quote": "^1.7.2"
+    "prettier": "^3.0.0",
+    "shell-quote": "^1.8.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,21 +1,21 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@mdx-js/loader': ^1.6.4
-  '@mdx-js/react': ^1.6.4
-  '@next/mdx': ^9.4.2
+  '@mdx-js/loader': ^2.4.1
+  '@mdx-js/react': ^2.4.1
+  '@next/mdx': ^14.1.0
   copee: ^1.0.6
-  husky: ^4.2.5
-  image-size: ^0.9.3
-  lint-staged: ^10.2.3
-  next: ^13.0.5
+  husky: ^8.0.0
+  image-size: ^1.0.0
+  lint-staged: ^15.0.0
+  next: ^14.1.0
   nprogress: ^0.2.0
-  prettier: ^2.0.5
+  prettier: ^3.0.0
   react: ^18.2.0
   react-dom: ^18.2.0
   react-gravatar: ^2.6.3
   react-highlighter: ^0.4.3
-  shell-quote: ^1.7.2
+  shell-quote: ^1.8.0
 
 dependencies:
   '@mdx-js/loader': 1.6.22_react@18.2.0


### PR DESCRIPTION
## Summary
- begin migrating from pages router by creating an `app` directory
- add `layout` and `providers` to replicate search context and analytics
- export the existing homepage through `app/page.js`
- update Next.js and related packages to latest versions
- enable `appDir` in Next configuration
- update lockfile specifiers

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: Cannot find module 'image-size')*